### PR TITLE
Feature/cdap support

### DIFF
--- a/edgeNodeSetup.sh
+++ b/edgeNodeSetup.sh
@@ -119,7 +119,7 @@ function checkFileExists
 echo "Copying configs and cluster resources local"
 tmpFilePath=~/tmpConfigs
 mkdir -p $tmpFilePath
-RESOURCEPATHS=(/etc/hadoop/conf /etc/hive/conf /etc/hbase/conf /var/lib/ambari-server/resources/scripts)
+RESOURCEPATHS=(/etc/hadoop/conf /etc/hive/conf /etc/hbase/conf /etc/tez/conf /var/lib/ambari-server/resources/scripts)
 for path in "${RESOURCEPATHS[@]}"
 do
 	echo "Copying directory $path"

--- a/edgeNodeSetup.sh
+++ b/edgeNodeSetup.sh
@@ -147,7 +147,7 @@ sshpass -e ssh $clusterSshUser@$clusterSshHostName "find /usr/bin -readable -lna
 #Get the hadoop binaries from the cluster
 binariesLocation=$(grep HADOOP_HOME "$tmpFilePath/usr/bin/hadoop" -m 1 | sed 's/.*:-//;s/\(.*\)hadoop}/\1/;s/\(.*\)\/.*/\1/')
 #For clients, get the current symlinks from the cluster
-currentSymlinks=$(sshpass -e ssh cask@dwapi2-ssh.azurehdinsight.net "find /usr/hdp/current -readable -lname '/usr/hdp/*' -exec test -e {} \; -print | tr '\n' ' '")
+currentSymlinks=$(sshpass -e ssh $clusterSshUser@$clusterSshHostName "find /usr/hdp/current -readable -lname '/usr/hdp/*' -exec test -e {} \; -print | tr '\n' ' '")
 #Zip the files
 echo "Zipping binaries on headnode"
 bitsFileName=hdpBits.tar.gz

--- a/edgeNodeSetup.sh
+++ b/edgeNodeSetup.sh
@@ -146,13 +146,15 @@ sshpass -e ssh $clusterSshUser@$clusterSshHostName "find /usr/bin -readable -lna
 
 #Get the hadoop binaries from the cluster
 binariesLocation=$(grep HADOOP_HOME "$tmpFilePath/usr/bin/hadoop" -m 1 | sed 's/.*:-//;s/\(.*\)hadoop}/\1/;s/\(.*\)\/.*/\1/')
+#For clients, get the current symlinks from the cluster
+currentSymlinks=$(sshpass -e ssh cask@dwapi2-ssh.azurehdinsight.net "find /usr/hdp/current -readable -lname '/usr/hdp/*' -exec test -e {} \; -print | tr '\n' ' '")
 #Zip the files
 echo "Zipping binaries on headnode"
 bitsFileName=hdpBits.tar.gz
 loggingBitsFileName=loggingBits.tar.gz
 tmpRemoteFolderName=tmpBits
 sshpass -e ssh $clusterSshUser@$clusterSshHostName "mkdir ~/$tmpRemoteFolderName"
-sshpass -e ssh $clusterSshUser@$clusterSshHostName "tar -cvzf ~/$tmpRemoteFolderName/$bitsFileName $binariesLocation &>/dev/null"
+sshpass -e ssh $clusterSshUser@$clusterSshHostName "tar -cvzf ~/$tmpRemoteFolderName/$bitsFileName $binariesLocation $currentSymlinks &>/dev/null"
 sshpass -e ssh $clusterSshUser@$clusterSshHostName "tar -cvzf ~/$tmpRemoteFolderName/$loggingBitsFileName /usr/lib/hdinsight-logging &>/dev/null"
 #Copy the binaries
 echo "Copying binaries from headnode"


### PR DESCRIPTION
These are general fixes to the resultant hadoop client configuration on the edgenode.  These changes were necessary in order to get CDAP to run on the edgenode after provisioning the `hdinsight-linux-with-edge-node` template.
- [x] including `/etc/tez/conf` in the list of configuration paths to be copied over to the edge node.  This is because the hive configuration in `/etc/hive/conf` specifies `tez` as the execution engine and so `/etc/tez/conf/...` must be there.
- [x] including all symlinks under `/usr/hdp/current` in the tarball created on the hdinsight cluster and copied over to the edgenode.  This is because some client configurations such as `$HIVE_CONF_DIR` are defined using `/usr/hdp/current/...`
